### PR TITLE
User provided tabix LD

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7843,8 +7843,8 @@
       }
     },
     "locuszoom": {
-      "version": "git+https://github.com/statgen/locuszoom.git#45c7ab2516298e4a6a0e177e63b6ac6545654086",
-      "from": "git+https://github.com/statgen/locuszoom.git#45c7ab2",
+      "version": "git+https://github.com/statgen/locuszoom.git#53ba107dc31e610609d8e92d019dff8b7d7b61cf",
+      "from": "git+https://github.com/statgen/locuszoom.git#53ba107",
       "requires": {
         "d3": "^5.16.0",
         "gwas-credible-sets": "^0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7843,8 +7843,8 @@
       }
     },
     "locuszoom": {
-      "version": "git+https://github.com/statgen/locuszoom.git#ce641a555f8c7dbebbaa4375bf146ce83c59646f",
-      "from": "git+https://github.com/statgen/locuszoom.git#ce641a5",
+      "version": "git+https://github.com/statgen/locuszoom.git#45c7ab2516298e4a6a0e177e63b6ac6545654086",
+      "from": "git+https://github.com/statgen/locuszoom.git#45c7ab2",
       "requires": {
         "d3": "^5.16.0",
         "gwas-credible-sets": "^0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7843,8 +7843,8 @@
       }
     },
     "locuszoom": {
-      "version": "git+https://github.com/statgen/locuszoom.git#780cfd836f2e8f07333a0235ce65fe87fd899630",
-      "from": "git+https://github.com/statgen/locuszoom.git#780cfd8",
+      "version": "git+https://github.com/statgen/locuszoom.git#ce641a555f8c7dbebbaa4375bf146ce83c59646f",
+      "from": "git+https://github.com/statgen/locuszoom.git#ce641a5",
       "requires": {
         "d3": "^5.16.0",
         "gwas-credible-sets": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@sentry/browser": "^4.5.2",
     "bootstrap": "^4.4.1",
     "bootstrap-vue": "^2.21.2",
-    "locuszoom": "git+https://github.com/statgen/locuszoom.git#780cfd8",
+    "locuszoom": "git+https://github.com/statgen/locuszoom.git#ce641a5",
     "lodash": "^4.17.11",
     "tabulator-tables": "^4.9.0",
     "vue": "^2.6.14",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@sentry/browser": "^4.5.2",
     "bootstrap": "^4.4.1",
     "bootstrap-vue": "^2.21.2",
-    "locuszoom": "git+https://github.com/statgen/locuszoom.git#45c7ab2",
+    "locuszoom": "git+https://github.com/statgen/locuszoom.git#53ba107",
     "lodash": "^4.17.11",
     "tabulator-tables": "^4.9.0",
     "vue": "^2.6.14",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@sentry/browser": "^4.5.2",
     "bootstrap": "^4.4.1",
     "bootstrap-vue": "^2.21.2",
-    "locuszoom": "git+https://github.com/statgen/locuszoom.git#ce641a5",
+    "locuszoom": "git+https://github.com/statgen/locuszoom.git#45c7ab2",
     "lodash": "^4.17.11",
     "tabulator-tables": "^4.9.0",
     "vue": "^2.6.14",

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,12 +4,13 @@ import 'locuszoom/dist/locuszoom.css';
 import { BCard, BCollapse, VBToggle } from 'bootstrap-vue/src/';
 
 import {
-    getBasicSources, getBasicLayout,
+    activateUserLD, getBasicSources, getBasicLayout,
 } from './util/lz-helpers';
 import { count_add_track, count_region_view, setup_feature_metrics } from './util/metrics';
 
 import PlotPanes from './components/PlotPanes.vue';
 import GwasToolbar from './components/GwasToolbar.vue';
+import { DATA_TYPES } from './util/constants';
 
 
 export default {
@@ -53,6 +54,13 @@ export default {
             } else {
                 // TODO: We presently ignore extra plot state (like region) when adding new tracks. Revisit for future data types.
                 this.$refs.plotWidget.addStudy(panel_configs, source_configs);
+                if (data_type === DATA_TYPES.PLINK_LD) {
+                    // Modify plot widget internals for LD. This implies a lot of coupling between pieces, but works for now.
+                    const source_name = source_configs[0][0]; // we happen to know that LD generates one datasource and name is first item of config
+                    this.$refs.plotWidget.$refs.assoc_plot.callPlot((plot) => {
+                        activateUserLD(plot, display_name, source_name);
+                    });
+                }
             }
 
             count_add_track(data_type);

--- a/src/App.vue
+++ b/src/App.vue
@@ -57,10 +57,8 @@ export default {
                 // TODO: We presently ignore extra plot state (like region) when adding new tracks. Revisit for future data types.
                 this.$refs.plotWidget.addStudy(panel_configs, source_configs);
                 if (data_type === DATA_TYPES.PLINK_LD) {
-                    // Modify plot widget internals for LD. This implies a lot of coupling between pieces, but works for now.
-                    const source_name = source_configs[0][0]; // we happen to know that LD generates one datasource and name is first item of config
                     this.$refs.plotWidget.$refs.assoc_plot.callPlot((plot) => {
-                        activateUserLD(plot, display_name, source_name);
+                        activateUserLD(plot, display_name);
                     });
                 }
             }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <script>
 
 import 'locuszoom/dist/locuszoom.css';
-import { BCard, BCollapse, VBToggle } from 'bootstrap-vue/src/';
+import { BCard, BCollapse, VBToggle, BTab, BTabs } from 'bootstrap-vue/src/';
 
 import {
     activateUserLD, getBasicSources, getBasicLayout,
@@ -16,9 +16,11 @@ import { DATA_TYPES } from './util/constants';
 export default {
     name: 'LocalZoom',
     components: {
-        GwasToolbar,
         BCollapse,
         BCard,
+        BTab,
+        BTabs,
+        GwasToolbar,
         PlotPanes,
     },
     directives: { VBToggle },
@@ -95,58 +97,189 @@ export default {
           class="btn btn-link">Instructions</button>
         <b-collapse
           id="instructions"
-          class="mt-2">
+          class="mt-1 mb-4">
           <b-card>
             <div class="card-text">
-              <p>
-                If you have found this tool useful, please cite our paper,
-                <a href="https://doi.org/10.1093/bioinformatics/btab186" target="_blank">LocusZoom.js:
-                interactive and embeddable visualization of genetic association study results</a> (Bioinformatics 2021).
-              </p>
+              <b-tabs card>
+                <b-tab title="General">
+                  <p>
+                    If you have found this tool useful, please cite our paper,
+                    <a href="https://doi.org/10.1093/bioinformatics/btab186" target="_blank">LocusZoom.js:
+                    interactive and embeddable visualization of genetic association study results</a> (Bioinformatics 2021).
+                  </p>
 
-              LocalZoom is a tool for generating region association plots via the web browser.
-              It can be used on any Tabix-indexed file (including those stored on your hard drive), which
-              makes it useful for sensitive or confidential data. If you are comfortable uploading
-              your data to a server, consider the <a href="https://my.locuszoom.org">my.locuszoom.org</a> upload service instead,
-              which provides additional annotation features and does not require you to compress or index your data.
-              (note that the upload service is limited to files &lt;= 1GB)
-              LocalZoom relies on four assumptions:
-              <ol>
-                <li>Your data is a text-based, tab-delimited file that has been stored in a compressed format,
-                and <a href="http://www.htslib.org/doc/tabix.html">indexed using Tabix</a>. The
-                index file must be in the same path, with the suffix <em>.tbi</em></li>
-                <li>The data is hosted in a place that is reachable by web browser (eg local files
-                or a service such as S3)
-                </li>
-                <li>If using a remote URL, the host location must support byte range requests. (<a
-                  href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests#Checking_if_a_server_supports_partial_requests">how
-                  to check</a>)
-                </li>
-                <li>Your file contains all of the information required to draw a plot. Chromosome, position,
-                ref, and alt alleles can be specified as either individual columns, or a variant
-                marker string (eg <code>chr:pos_ref/alt</code>); there must also be a p-value
-                (or -log10 pvalue) for each variant as a separate column. Beta, SE, and alt allele
-                frequency information are optional, but will be used on the plot if provided.
-                <em>Client-side plots cannot be generated from rsIDs.</em></li>
-              </ol>
+                  <p>
+                    LocalZoom is a tool for generating region association plots via the web browser.
+                    It can be used on any Tabix-indexed file (including those stored on your hard drive), which
+                    makes it useful for sensitive or confidential data. If you are comfortable uploading
+                    your data to a server, consider the <a href="https://my.locuszoom.org">my.locuszoom.org</a> upload service instead,
+                    which provides additional annotation features and does not require you to compress or index your data.
+                    (note that the upload service is limited to files &lt;= 1GB)
+                    LocalZoom relies on four assumptions:
+                  </p>
+                  <ol>
+                    <li>Your data is a text-based, tab-delimited file that has been stored in a compressed format,
+                    and <a href="http://www.htslib.org/doc/tabix.html">indexed using Tabix</a>. The
+                    index file must be in the same path, with the suffix <em>.tbi</em></li>
+                    <li>The data is hosted in a place that is reachable by web browser (eg local files
+                    or a service such as S3)
+                    </li>
+                    <li>If using a remote URL, the host location must support byte range requests. (<a
+                      href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests#Checking_if_a_server_supports_partial_requests">how
+                      to check</a>)
+                    </li>
+                    <li>Your file contains all of the information required to draw a plot (see individual file format instructions for details).</li>
+                  </ol>
 
-              <p>This service is designed to efficiently fetch only the data needed for the plot
-              region of interest. Therefore, it cannot generate summary views that would require
-              processing the entire file (eg Manhattan plots).
-              </p>
+                  <p>
+                    This service is designed to efficiently fetch only the data needed for the plot
+                    region of interest. Therefore, it cannot generate summary views that would require
+                    processing the entire file (eg Manhattan plots).
+                  </p>
 
-              <p>
-                LD and overlay information is based on a specific human genome build (<strong>build GRCh37</strong>
-                or <strong>build GRCh38</strong> are supported). Exercise caution when interpreting
-                plots based on a GWAS with positions from a different build.
-              </p>
+                  <p>
+                    LD and overlay information is based on a specific human genome build (<strong>build GRCh37</strong>
+                    or <strong>build GRCh38</strong> are supported). Exercise caution when interpreting
+                    plots based on a GWAS with positions from a different build.
+                  </p>
 
-              <p>
-                Credible sets are
-                <a href="https://github.com/statgen/gwas-credible-sets/">calculated</a> based on the
-                p-values for the displayed region. At the moment this tool does not support
-                uploading your own custom credible set annotations.
-              </p>
+                  <p>
+                    Credible sets are
+                    <a href="https://github.com/statgen/gwas-credible-sets/">calculated</a> based on the
+                    p-values for the displayed region. At the moment this tool does not support
+                    uploading your own custom credible set annotations.
+                  </p>
+                </b-tab>
+
+                <b-tab title="GWAS">
+                  <h3>What data is required?</h3>
+                  <p>
+                    LocalZoom can read GWAS summary statistics from many file formats. When you add a
+                    study, we will attempt to automatically detect the columns for particular fields
+                    of interest, based on heuristic rules derived from several dozen common programs
+                    or file formats. The <a href="https://my.locuszoom.org/about/#prepare-data">required fields</a>
+                    are the same as for my.locuszoom.org, a related tool also developed at UMich.
+                    When you load a file, you will be asked to confirm the auto-determined options.
+                  </p>
+
+                  <h3>How should I prepare my files?</h3>
+                  <p>
+                    We attempt to support many GWAS file formats, and hence there is no single set of
+                    instructions for everyone. Below is a sample command that may be helpful; it is presented as several commands in
+                    a sequence, so that it can be run all at once as part of a data preparation workflow (like snakemake).
+                  </p>
+                  <p>
+                    To support sorting and tabix indexing, your file will need to specify chromosome and position as separate fields, with tab delimiters.
+                    The example below assumes one header row, with chromosome as column 1 and position as column 2.
+                  </p>
+                  <dl>
+                    <dt>Sort file, compress, and tabix-index results</dt>
+                    <dd>
+                      Assuming that your chromosome is in column 1 and position in column 2, with one header row (skipped in both the awk "NR" command and the tabix --skip-lines flag):
+                      <code>zcat &lt; summstats.tab.gz | awk 'NR&lt;=1{print $0;next}{print $0| "sort -k1,1V -k2,2n"}' | bgzip -c &gt; summstats.sorted.tab.gz && tabix -s1 -b 2 -e 2 --skip-lines 1 -f summstats.sorted.tab.gz</code><br>
+                    </dd>
+
+                    <dt>(rarely needed) Converting to tab delimiters</dt>
+                    <dd>
+                      Most modern GWAS programs output tab-delimited results (in each row, columns are separated via a tab character)- this makes it much easier to use popular generic indexing tools like tabix.
+                      Some old programs (such as PLINK 1.x) may generate files that use a different character
+                      ("space delimited" or "fixed width" formats), and append extra spaces to the start and end of a row.
+                      In the rare case where you need to accommodate such a program, the following command may be helpful to clean up the file format before use:<br>
+                      <code>cat filename.txt | sed 's/^[[:space:]]*//g' | sed 's/[[:space:]]*$//g' | tr -s ' ' '\t' &gt; > filename.tab</code>
+                    </dd>
+                  </dl>
+                </b-tab>
+
+                <b-tab title="BED files">
+                  <p>
+                    BED files are a <a href="https://genome.ucsc.edu/FAQ/FAQformat.html#format1">standard format</a> with 3-12 columns of data.
+                    The default LocusZoom panel layout for a BED track will use chromosome, position, line name, and (optionally) color
+                    to draw the plot. Score will be shown as a tooltip field (if present); it may have a different meaning and scale
+                    depending on the contents of your BED file. As with any LocusZoom track, custom layouts can be created to render data in different ways, or to use more or
+                    fewer columns based on the data of interest.
+                  </p>
+
+                  <p>
+                    The following command is helpful for preparing BED files for use in the browser:<br>
+                    <code>$ sort -k1,1 -k2,2n input.bed | bgzip &gt; input-sorted.bed.gz && tabix -p bed input-sorted.bed.gz</code><br>
+                    Some BED files will have one or more header rows; in this case, modify the tabix command with: <code>--skip-lines N</code> (where N is the number of headers).
+                  </p>
+                </b-tab>
+
+                <b-tab title="PLINK 1.9 LD">
+                  <h3>Before you begin</h3>
+                  <p>
+                    Although PLINK is targeted as a (historically) popular tool for computing LD,
+                    the file format it generates must be transformed before using in a plot. Read these instructions carefully for help using the data with LocalZoom.
+                    We presently do not support arbitrary file formats, as this is an area of active innovation and there is no single clear standard.
+                    We welcome feedback on generally useful improvements; the current process is rather kludgy!
+                  </p>
+                  <h3>Purpose</h3>
+                  <p>
+                    Linkage Disequilibrium is an important tool for interpreting LocusZoom.js plots. In order to support viewing any
+                    region, most LocusZoom.js usages take advantage of the Michigan LD server to calculate region-based LD relative
+                    to a particular reference variant, based on the well-known 1000G reference panel.
+                  </p>
+
+                  <p>
+                    We recognize that the 1000G reference panel (and its sub-populations) is not suited to all cases, especially for
+                    studies with ancestry-specific results or large numbers of rare variants not represented in a public panel.
+                    For many groups, <a href="https://github.com/statgen/LDServer/">setting up a private LD Server instance</a> is not an option.
+                    As a fallback, we support parsing a file format derived from PLINK 1.9 `--ld-snp` calculations. Instructions
+                    for preparing these files are provided below. <strong>Due to the potential for very large output files, we only
+                    support pre-calculated LD relative to one (or a few) LD reference variants; this means that this feature
+                    requires some advance knowledge of interesting regions in order to be useful.</strong> If the user views any
+                    region that is not near a pre-provided reference variant, they will see grey dots indicating the absence of LD information.
+                    We have intentionally restricted the demo so that this limitation is clear.
+                  </p>
+
+                  <h3>How to run PLINK and format output</h3>
+                  <dl>
+                    <dt><b>Preparing genotype files: harmonizing ID formats</b></dt>
+                    <dd>
+                      LocusZoom typically calculates LD relative to a variant by EPACTS-format specifier (chrom:pos_ref/alt).
+                      However, genotype VCF files have no single standard for how variants are identified, which can make it hard to match the requested variant to the actual data.
+                      Some files are not even internally consistent, which makes it hard to write easy copy-and-paste commands that would work widely
+                      across files. Your file can be transformed to match the tutorial assumptions via common tool and the command below:<br>
+
+                      <code>bcftools annotate -Oz --set-id '%CHROM\:%POS\_%REF\/%ALT' original_vcf.gz &gt; vcfname_epacts_id_format.gz</code><br>
+
+                      <em>In some rare cases (such as <a href="https://www.internationalgenome.org/faq/why-are-there-duplicate-calls-in-the-phase-3-call-set">1000G phase 3</a>), data preparation errors may result in duplicate entries for the same variant. This can break PLINK. A command such as the one below can be used to find these duplicates:<br>
+                        <code>zcat &lt; vcfname_epacts_id_format.gz | cut -f3 | sort | uniq -d</code><br>
+                        They can then be removed using the following command (check the output carefully before using, because reasons for duplicate lines vary widely):
+                      </em><br>
+                      <code>bcftools norm -Oz --rm-dup all vcfname_epacts_id_format.gz &gt; vcfname_epacts_id_format_rmdups.gz</code>
+                    </dd>
+
+                    <dt><b>Calculating LD relative to reference variants</b></dt>
+                    <dd>
+                      The command below will calculate LD relative to (several) variants in a 500 kb region centered around each reference variant.<br>
+                      <code>plink-1.9 --r2 --vcf vcfname_epacts_id_format.gz --ld-window 499999 --ld-window-kb 500 --ld-window-r2 0.0 --ld-snp-list mysnplist.txt</code><br>
+
+                      This command assumes the presence of a file named <em>mysnplist.txt</em>, which contains a series of rows like the example below:<br>
+                      <pre style="background: #F4F4F4">16:53842908_G/A
+16:53797908_C/G
+16:53809247_G/A</pre>
+                    </dd>
+                    <dt><b>Preparing the LD output file for use with LocusZoom.js</b></dt>
+                    <dd>
+                      As of this writing, this tutorial assumes a "list of SNPs" feature that requires PLINK 1.9.x (and is not yet available in newer versions).
+                      Unfortunately, PLINK's default output format is not compatible with tabix, for historical reasons.
+                      Transform to a format readable by LocusZoom via the following sequence of commands.<br>
+                      <code>cat plink.ld | tail -n+2 | sed 's/^[[:space:]]*//g' | sed 's/[[:space:]]*$//g' | tr -s ' ' '\t' | sort -k4,4 -k5,5n | bgzip &gt; plink.ld.tab.gz && tabix -s4 -b5 -e5 plink.ld.tab.gz</code>
+                    </dd>
+
+                    <dt><b>I don't use PLINK; how should my file be formatted?</b></dt>
+                    <dd>
+                      A custom LD file should be tab-delimited. It should specify a reference variant ("SNP_A") and LD for all others relative to that variant ("SNP_B"). The first two rows will look like the following example, taken from actual PLINK output:
+                      <pre style="background: #F4F4F4">CHR_A&#9;BP_A&#9;SNP_A&#9;CHR_B&#9;BP_B&#9;SNP_B&#9;R2
+22&#9;37470224&#9;22:37470224_T/C&#9;22&#9;37370297&#9;22:37370297_T/C&#9;0.000178517</pre>
+
+                      <em>Note: pre-calculated LD files can easily become very large. We recommend only outputting LD relative to a few target reference variants at a time.</em>
+                    </dd>
+                  </dl>
+                </b-tab>
+              </b-tabs>
             </div>
           </b-card>
         </b-collapse>

--- a/src/App.vue
+++ b/src/App.vue
@@ -175,7 +175,9 @@ export default {
                   <dl>
                     <dt>Sort file, compress, and tabix-index results</dt>
                     <dd>
-                      Assuming that your chromosome is in column 1 and position in column 2, with one header row (skipped in both the awk "NR" command and the tabix --skip-lines flag):
+                      Many programs already output summary statistics sorted by chromosome and position. If your tool does not, then you will need to sort the file before creating a tabix index (tabix is a tool that allows someone to query a file for all data in a contiguous genomic region).
+                      If your data is already sorted, then the "awk" step can be omitted, but you will still need to run <i>bgzip</i> and <i>tabix</i>.
+                      Assuming that your chromosome is in column 1 and position in column 2, with one header row (skipped in both the awk "NR" command and the tabix --skip-lines flag):<br>
                       <code>zcat &lt; summstats.tab.gz | awk 'NR&lt;=1{print $0;next}{print $0| "sort -k1,1V -k2,2n"}' | bgzip -c &gt; summstats.sorted.tab.gz && tabix -s1 -b 2 -e 2 --skip-lines 1 -f summstats.sorted.tab.gz</code><br>
                     </dd>
 

--- a/src/components/ExportData.vue
+++ b/src/components/ExportData.vue
@@ -8,6 +8,7 @@ import LocusZoom from 'locuszoom';
 
 import { sourceName } from '../util/lz-helpers';
 import TabulatorTable from './TabulatorTable.vue';
+import { DATA_TYPES } from '../util/constants';
 
 function formatSciNotation(cell, params) {
     // Tabulator cell formatter using sci notation
@@ -39,7 +40,7 @@ export default {
         },
 
         gwas_tracks() {
-            return this.known_tracks.filter(({data_type}) => data_type === 'gwas');
+            return this.known_tracks.filter(({data_type}) => data_type === DATA_TYPES.GWAS);
         },
 
         table_config() {

--- a/src/components/GwasToolbar.vue
+++ b/src/components/GwasToolbar.vue
@@ -142,7 +142,7 @@ export default {
         class="col-sm-6">
         <div v-if="study_count < max_studies">
           <tabix-adder
-            :allow_ld="false"
+            :allow_ld="study_count > 0"
             @ready="receiveTabixReader"
             @fail="showMessage"
           />

--- a/src/components/RegionPicker.vue
+++ b/src/components/RegionPicker.vue
@@ -1,5 +1,4 @@
 <template>
-
   <form class="form-inline" @submit.prevent="selectRegion">
     <vue-bootstrap-typeahead
       :data="search_results"

--- a/src/components/RegionPicker.vue
+++ b/src/components/RegionPicker.vue
@@ -1,15 +1,17 @@
 <template>
-  <div class="form-inline">
+
+  <form class="form-inline" @submit.prevent="selectRegion">
     <vue-bootstrap-typeahead
       :data="search_results"
       v-model="region"
       :serializer="s => s.term"
       :min-matching-chars="3"
       placeholder="chr:start-end, rs, or gene"/>
-    <button
+    <input
       class="btn btn-primary"
-      @click="selectRegion">Go to region</button>
-  </div>
+      type="submit"
+      value="Go to region">
+  </form>
 </template>
 
 <script>

--- a/src/components/TabixAdder.vue
+++ b/src/components/TabixAdder.vue
@@ -295,7 +295,7 @@ export default {
               name="data-type"
               value="plink_ld"
             >
-              PLINK 1.9 LD (overlay on GWAS)
+              PLINK 1.9 LD (overlay on GWAS; see guide above)
             </b-form-radio>
           </b-form-group>
 

--- a/src/components/TabixAdder.vue
+++ b/src/components/TabixAdder.vue
@@ -7,6 +7,7 @@ import { makeBed12Parser, makeGWASParser, makePlinkLdParser } from 'locuszoom/es
 import { blobReader, urlReader } from 'tabix-reader';
 
 import GwasParserOptions from './GwasParserOptions.vue';
+import { DATA_TYPES } from '../util/constants';
 import { positionToStartRange } from '../util/entity-helpers';
 
 
@@ -21,13 +22,16 @@ export default {
         return {
             tabix_mode: 'file',
             display_name: '',
-            data_type: 'gwas',
+            data_type: DATA_TYPES.GWAS,
             tabix_gz_url: '',
             // Options required to pass props to the GWAS modal
             filename: '',
             show_gwas_modal: false,
             tabix_reader: null,
         };
+    },
+    beforeCreate() {
+        this.DATA_TYPES = DATA_TYPES;
     },
     methods: {
         reset() {
@@ -105,7 +109,7 @@ export default {
         suggestRegion(data_type, reader, parser) {
             // Note; the GWAS modal does this for GWAS data internally.
             return new Promise((resolve, reject) => {
-                if (data_type === 'bed') {
+                if (data_type === DATA_TYPES.BED) {
                     // 1. Find headers (has tabs, does not begin with "browser", "track", or comment mark)
                     // 2. Get first data row and return the coordinates for that row. This method assumes the LZ parser with field names according to UCSC BED spec
                     const header_prefixes = /^(browser | track |#)/;
@@ -165,7 +169,7 @@ export default {
             }
 
             reader_promise.then(([reader, filename]) => {
-                if (data_type === 'gwas') {
+                if (data_type === DATA_TYPES.GWAS) {
                     // GWAS files are very messy, and so knowing where to find the file is not enough.
                     // After receiving the reader, we need to ask the user how to parse the file. (via UI)
                     if (filename.includes('.bed')) {
@@ -180,12 +184,12 @@ export default {
                     // All other data types are quasi-standardized, and hence we can declare this
                     //  new track immediately after verifying that a valid reader exists
                     let parser;
-                    if (data_type === 'bed') {
+                    if (data_type === DATA_TYPES.BED) {
                         parser = makeBed12Parser({normalize: true});
                         if (!filename.includes('.bed')) {
                             throw new Error('BED interval file names must include extension .bed');
                         }
-                    } else if (data_type === 'plink_ld') {
+                    } else if (data_type === DATA_TYPES.PLINK_LD) {
                         parser = makePlinkLdParser({normalize: true});
                     } else {
                         throw new Error('Unrecognized datatype');
@@ -208,7 +212,7 @@ export default {
             const { tabix_reader, filename, display_name } = this;
             // Receive GWAS options and declare a new track for this datatype
             const parser = makeGWASParser(parser_config);
-            this.sendTrackOptions('gwas', tabix_reader, parser, filename, display_name, region_config);
+            this.sendTrackOptions(DATA_TYPES.GWAS, tabix_reader, parser, filename, display_name, region_config);
             this.reset();
         },
 

--- a/src/components/TabixAdder.vue
+++ b/src/components/TabixAdder.vue
@@ -145,10 +145,9 @@ export default {
                     });
                 } else {
                     // Not implemented for other datatypes
-                    return {};
+                    resolve({});
                 }
             });
-
         },
 
         createReader(event) {
@@ -172,11 +171,10 @@ export default {
                 if (data_type === DATA_TYPES.GWAS) {
                     // GWAS files are very messy, and so knowing where to find the file is not enough.
                     // After receiving the reader, we need to ask the user how to parse the file. (via UI)
-                    if (filename.includes('.bed')) {
+                    if (filename.includes('.bed') || filename.includes('.ld')) {
                         // Check in case the user does something unwise. (2500 unique BED lines would be bad!)
-                        throw new Error('Selected datatype GWAS does not match file extension .bed');
+                        throw new Error('Wrong file extension for selected data type "GWAS"');
                     }
-
                     this.filename = filename;
                     this.tabix_reader = reader;
                     this.show_gwas_modal = true;
@@ -191,6 +189,9 @@ export default {
                         }
                     } else if (data_type === DATA_TYPES.PLINK_LD) {
                         parser = makePlinkLdParser({normalize: true});
+                        if (!filename.includes('.ld')) {
+                            throw new Error('User PLINK LD file names must include extension .ld');
+                        }
                     } else {
                         throw new Error('Unrecognized datatype');
                     }
@@ -294,7 +295,7 @@ export default {
               name="data-type"
               value="plink_ld"
             >
-              PLINK 1.9 LD
+              PLINK 1.9 LD (overlay on GWAS)
             </b-form-radio>
           </b-form-group>
 

--- a/src/util/constants.js
+++ b/src/util/constants.js
@@ -6,7 +6,15 @@ const REGEX_REGION = /^(?:chr)?(\w+)\s*:\s*(\d+)-(\d+)$/;
 
 const DEFAULT_REGION_SIZE = 500000;
 
+// Enum that controls recognized data types, so we can rename/ adjust as needed.
+const DATA_TYPES = Object.freeze({
+    BED: 'bed',
+    GWAS: 'gwas',
+    PLINK_LD: 'plink_ld',
+});
+
 export {
+    DATA_TYPES,
     DEFAULT_REGION_SIZE,
     REGEX_REGION, REGEX_POSITION,
     PORTAL_API_BASE_URL, LD_SERVER_BASE_URL,

--- a/src/util/lz-helpers.js
+++ b/src/util/lz-helpers.js
@@ -57,12 +57,16 @@ function createGwasStudyLayout(
         assoc: `assoc_${track_id}`,
     };
 
-    const assoc_panel = LocusZoom.Layouts.get('panel', 'association', {
+    let assoc_panel = LocusZoom.Layouts.get('panel', 'association', {
         id: `association_${track_id}`,
         title: { text: display_name },
         height: 275,
         namespace,
     });
+
+    // The PortalDev API uses a different name for the SE field. LocalZoom is a bit more descriptive.
+    assoc_panel = LocusZoom.Layouts.renameField(assoc_panel, 'assoc:se', 'assoc:stderr_beta', false);
+
     const assoc_layer = assoc_panel.data_layers[2]; // layer 1 = recomb rate
     assoc_layer.label = {
         text: '{{#if assoc:rsid}}{{assoc:rsid}}{{#else}}{{assoc:variant}}{{/if}}',

--- a/src/util/lz-helpers.js
+++ b/src/util/lz-helpers.js
@@ -4,7 +4,7 @@ import tabixSource from 'locuszoom/esm/ext/lz-tabix-source';
 import intervalTracks from 'locuszoom/esm/ext/lz-intervals-track';
 import lzParsers from 'locuszoom/esm/ext/lz-parsers';
 
-import { PORTAL_API_BASE_URL, LD_SERVER_BASE_URL } from './constants';
+import { PORTAL_API_BASE_URL, LD_SERVER_BASE_URL, DATA_TYPES } from './constants';
 
 LocusZoom.use(credibleSets);
 LocusZoom.use(tabixSource);
@@ -145,9 +145,9 @@ function createGwasStudyLayout(
 function createStudyLayouts (data_type, filename, display_name, annotations) {
     const track_id = `${data_type}_${sourceName(filename)}`;
 
-    if (data_type === 'gwas') {
+    if (data_type === DATA_TYPES.GWAS) {
         return createGwasStudyLayout(track_id, display_name, annotations);
-    } else if (data_type === 'bed') {
+    } else if (data_type === DATA_TYPES.BED) {
         return [
             LocusZoom.Layouts.get('panel', 'bed_intervals', {
                 id: track_id,
@@ -155,7 +155,7 @@ function createStudyLayouts (data_type, filename, display_name, annotations) {
                 title: { text: display_name },
             }),
         ];
-    } else if (data_type === 'plink_ld') {
+    } else if (data_type === DATA_TYPES.PLINK_LD) {
         throw new Error('Not yet implemented');
     } else {
         throw new Error('Unrecognized datatype');
@@ -187,13 +187,13 @@ function createGwasTabixSources(track_id, tabix_reader, parser_func) {
 function createStudySources(data_type, tabix_reader, filename, parser_func) {
     // todo rename to GET from CREATE, for consistency
     const track_id = `${data_type}_${sourceName(filename)}`;
-    if (data_type === 'gwas') {
+    if (data_type === DATA_TYPES.GWAS) {
         return createGwasTabixSources(track_id, tabix_reader, parser_func);
-    } else if (data_type === 'bed') {
+    } else if (data_type === DATA_TYPES.BED) {
         return [
             [track_id, ['TabixUrlSource', {reader: tabix_reader, parser_func }]],
         ];
-    } else if (data_type === 'plink_ld') {
+    } else if (data_type === DATA_TYPES.PLINK_LD) {
         throw new Error('Not yet implemented');
     } else {
         throw new Error('Unrecognized datatype');

--- a/src/util/lz-helpers.js
+++ b/src/util/lz-helpers.js
@@ -286,7 +286,7 @@ function activateUserLD(plot, display_name, source_id) {
     }
     // Update the UI help button EVERY time user LD is added, eg let user swap out LD to a different file when they switch regions
     //  (I'd RATHER they provide LD into all one file for regions, while still being a small file. But let's expect the most kludgy workflows to win)
-    const caption = `This plot is being rendered with user-provided LD. The filename is: ${escape(display_name)}`;
+    const caption = `This plot is being rendered with user-provided LD. The filename is: <b>${escape(display_name)}</b>`;
     LocusZoom.Layouts.mutate_attrs(plot.layout, '$..widgets[?(@.tag === "user_ld_description")].menu_html', caption);
     widget.show();
 


### PR DESCRIPTION
Allow the user to provide their own tabix format LD information when generating a plot.

Also improves user documentation, based on prose from the new LZ tabix tracks demo. A "sneak peek" version is deployed to my personal account for test purposes:
https://abought.github.io/localzoom/

This will require careful testing and will be deployed to a smaller set of local users before becoming widely available.